### PR TITLE
Install and setup pixy2 ROS driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = src/ds4_driver
 	url = https://github.com/naoki-mizuno/ds4_driver
 	branch = noetic-devel
+[submodule "src/pixy2_ros"]
+	path = src/pixy2_ros
+	url = https://github.com/zhiquanyeo/pixy2_ros.git

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install:
 	curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add
 	sudo apt update
 	sudo apt install ros-noetic-ros-base
-	sudo apt install python3-pip python3-rosdep python3-rosinstall python3-rosinstall-generator python3-wstool build-essential
+	sudo apt install python3-pip python3-rosdep python3-rosinstall python3-rosinstall-generator python3-wstool build-essential g++ libusb-1.0-0-dev
 	echo "source /opt/ros/noetic/setup.bash" >> ~/.bashrc
 	source ~/.bashrc
 	sudo rosdep init
@@ -20,6 +20,10 @@ install:
 	git clone https://github.com/mcfrappe/laff-platooning ~/laff-platooning
 	cd ~/laff-platooning && git submodule update --init --recursive
 	cd ~/laff-platooning && sudo pip install -r requirements.txt
+
+	sudo cp ~/laff-platooning/src/pixy2_ros/pixy2_node/pixy2/src/host/linux/pixy.rules /etc/udev/rules.d/
+	sudo udevadm control --reload-rules
+	sudo udevadm trigger
 
 cat:
 	rm -rf build


### PR DESCRIPTION
Installs a pre-existing ROS driver for pixy2 as a git submodule (https://github.com/zhiquanyeo/pixy2_ros). The driver will be automatically built when calling `catkin_make`. To set it up on an already installed device, run the following inside the root of the repo:

```
git submodule update --init --recursive
sudo apt install g++ libusb-1.0-0-dev
sudo cp src/pixy2_ros/pixy2_node/pixy2/src/host/linux/pixy.rules /etc/udev/rules.d/
sudo udevadm control --reload-rules
sudo udevadm trigger
```

Pixy2 "blocks" can be accessed via the `block_data` topic, which will publish a message containing a list of all detected blocks and information about them. 

The pixy2 node can be added to a launch file like so:
```xml
<node name="pixy2_node" pkg="pixy2_node" type="pixy2_node" output="screen">
    <param name="rate" value="50.0"/>
    <param name="use_servos" value="true"/>
</node>
```