### PR TITLE
Fix typo, make pid_min and pid_max optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Open Advanced Course in Embedded Systems (1TE722, 5 hp)
 ## Background
 Truck platooning is a technology that enables two or more trucks to travel together in a coordinated way, using wireless communication and automated driving systems. The main benefit of this technology is to reduce fuel consumption and emissions, as well as to improve traffic flow and safety. The trucks form a close-following convoy, where the leading truck sets the speed and direction, and the following trucks automatically adjust their movements accordingly. The drivers remain in control of their vehicles at all times, and can choose to join or leave the platoon as they wish. Truck platooning is currently being tested and developed in various countries, with the aim of making it a viable option for long-distance freight transport in the future.
 
-Some research has already been made in regards to platooning. In a [brief paper](https://www.sciencedirect.com/science/article/abs/pii/S0005109817301838) written by Ivo Herman, Steffi Knorn and Anders Ahlén a bidirectional system between the vehicles is looked at,. where a vehicle is not only reacting to what the vehicle in front is doing but also vice versa. This approach has given inspiration to this project.
+Some research has already been made in regards to platooning. In a [brief paper](https://www.sciencedirect.com/science/article/abs/pii/S0005109817301838) written by Ivo Herman, Steffi Knorn and Anders Ahlén a bidirectional system between the vehicles is looked at, where a vehicle is not only reacting to what the vehicle in front is doing but also vice versa. This approach has given inspiration to this project.
 
 ## Objectives
 

--- a/src/controller/src/controller/pid.py
+++ b/src/controller/src/controller/pid.py
@@ -1,6 +1,4 @@
-class PID:
-    # TODO: pid_min and pid_max should be optional
-    def __init__(self, kp, ki, kd, dt: int, pid_min: float, pid_max: float):
+def __init__(self, kp, ki, kd, dt: int, pid_min: float = None, pid_max: float = None):
         self.error = 0
         self.error_integral = 0
         self.error_derivative = 0
@@ -8,8 +6,9 @@ class PID:
         self.Ki = ki
         self.Kd = kd
         self.dt = dt
-        self.pid_min = pid_min
-        self.pid_max = pid_max
+
+        self.pid_min = pid_min if pid_min is not None else -float('inf')
+        self.pid_max = pid_max if pid_max is not None else float('inf')
 
     def update(self, error: float):
         error_prev = self.error

--- a/src/controller/src/controller/pid.py
+++ b/src/controller/src/controller/pid.py
@@ -1,4 +1,5 @@
-def __init__(self, kp, ki, kd, dt: int, pid_min: float = None, pid_max: float = None):
+class PID:
+    def __init__(self, kp, ki, kd, dt: int, pid_min: float = None, pid_max: float = None):
         self.error = 0
         self.error_integral = 0
         self.error_derivative = 0


### PR DESCRIPTION
Fixes a small typo in the README. 

Make the pid min and max values optional, as it is not always necessary to clamp the output. 